### PR TITLE
Update package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,31 +16,35 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>roscpp</build_depend>
-  <build_depend>hardware_interface</build_depend>
-  <build_depend>transmission_interface</build_depend>
   <build_depend>controller_manager</build_depend>
+  <build_depend>hardware_interface</build_depend>
   <build_depend>moveit_ros_planning_interface</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>transmission_interface</build_depend>
 
-  <run_depend>roscpp</run_depend>
-  <run_depend>hardware_interface</run_depend>
-  <run_depend>transmission_interface</run_depend>
   <run_depend>controller_manager</run_depend>
-  <run_depend>moveit_ros_planning_interface</run_depend>
-
-  <run_depend>moveit_ros_move_group</run_depend>
+  <run_depend>hardware_interface</run_depend>
+  <run_depend>joint_state_controller</run_depend>
+  <run_depend>joint_state_publisher_gui</run_depend>
+  <run_depend>joint_state_publisher</run_depend>
+  <run_depend>jsk_rviz_plugins</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
+  <run_depend>moveit_ros_move_group</run_depend>
+  <run_depend>moveit_ros_planning_interface</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>
   <run_depend>moveit_setup_assistant</run_depend>
-  <run_depend>joint_state_publisher</run_depend>
-  <run_depend>joint_state_publisher_gui</run_depend>
+  <run_depend>mycobot_description</run_depend>
+  <run_depend>myCobotROS</run_depend>
+  <run_depend>position_controllers</run_depend>
   <run_depend>robot_state_publisher</run_depend>
+  <run_depend>roscpp</run_depend>
   <run_depend>tf2_ros</run_depend>
-  <run_depend>xacro</run_depend>
+  <run_depend>transmission_interface</run_depend>
   <!-- This package is referenced in the warehouse launch files, but does not build out of the box at the moment. Commented the dependency until this works. -->
   <!-- <run_depend>warehouse_ros_mongo</run_depend> -->
-  <run_depend>myCobotROS</run_depend>
+  <run_depend>xacro</run_depend>
 
 </package>


### PR DESCRIPTION
`package.xml`に定義する依存関係にあるパッケージのアップデートです。

`config/trajectory_controller.yaml`で呼び出されている`joint_state_controller`と`position_controllers`を追加しています。

また、RVizで以下のプラグインを使用しているようだったので追加しています。

[jsk_rviz_plugin](http://wiki.ros.org/jsk_rviz_plugins)

このプラグインがインストールされていないと以下のエラーが出るようです。

```
[ERROR] [1611762285.394380944]: PluginlibFactory: The plugin for class 'jsk_rviz_plugin/TFTrajectory' failed to load.  Error: According to the loaded plugin descriptions the class jsk_rviz_plugin/TFTrajectory with base class type rviz::Display does not exist. Declared types are  moveit_rviz_plugin/MotionPlanning moveit_rviz_plugin/PlanningScene moveit_rviz_plugin/RobotState moveit_rviz_plugin/Trajectory rviz/Axes rviz/Camera rviz/DepthCloud rviz/Effort rviz/FluidPressure rviz/Grid rviz/GridCells rviz/Illuminance rviz/Image rviz/InteractiveMarkers rviz/LaserScan rviz/Map rviz/Marker rviz/MarkerArray rviz/Odometry rviz/Path rviz/PointCloud rviz/PointCloud2 rviz/PointStamped rviz/Polygon rviz/Pose rviz/PoseArray rviz/PoseWithCovariance rviz/Range rviz/RelativeHumidity rviz/RobotModel rviz/TF rviz/Temperature rviz/WrenchStamped rviz_plugin_tutorials/Imu
```

この変更を加えたあとは、READMEにある以下は不要かもしれません。
その次のステップにある`rosdep install -i --from-paths mycobot_moveit`で必要なパッケージが入ると思います（未確認）。

> 1. Install moveit.
> `sudo apt install ros-melodic-moveit`
> 
> If some errors happen when running moveit, try the following command:  
> `sudo apt install ros-melodic-ros-control ros-melodic-ros-controllers ros-melodic-joint-state-controller ros-melodic-effort-controllers ros-melodic-position-controllers`
> 
> 3. Install jsk rviz plugin
> `sudo apt install ros-melodic-jsk-visualization`


（記録のためPR/issueは英語のほうが良い、等あれば教えてください）